### PR TITLE
Makes it possible to switch off FORCE_DB by setting to 'false'. Otherwis...

### DIFF
--- a/test_utils/runner.py
+++ b/test_utils/runner.py
@@ -84,7 +84,7 @@ class RadicalTestSuiteRunner(django_nose.NoseTestSuiteRunner):
             except StandardError:  # TODO: Be more discerning but still DB
                                    # agnostic.
                 return True
-            return not not os.getenv('FORCE_DB')
+            return os.getenv('FORCE_DB', 'false').lower() != 'false'
 
         def sql_reset_sequences(connection):
             """Return a list of SQL statements needed to reset all sequences


### PR DESCRIPTION
...e, the only way to disable it after having set it once is to use `FORCE_DB= ./manage.py test ...` which isn't great.
