### PR TITLE
skip resets

### DIFF
--- a/test_utils/runner.py
+++ b/test_utils/runner.py
@@ -121,12 +121,13 @@ class RadicalTestSuiteRunner(django_nose.NoseTestSuiteRunner):
                 print ('Reusing old database "%s". Set env var FORCE_DB=1 if '
                        'you need fresh DBs.' % test_db_name)
 
-                # Reset auto-increment sequences. Apparently, SUMO's tests are
-                # horrid and coupled to certain numbers.
-                cursor = connection.cursor()
-                for statement in sql_reset_sequences(connection):
-                    cursor.execute(statement)
-                connection.commit_unless_managed()  # which it is
+                if getattr(settings, 'SQL_RESET_SEQUENCES', True):
+                    # Reset auto-increment sequences. Apparently, SUMO's tests
+                    # are horrid and coupled to certain numbers.
+                    cursor = connection.cursor()
+                    for statement in sql_reset_sequences(connection):
+                        cursor.execute(statement)
+                    connection.commit_unless_managed()  # which it is
 
                 creation.__class__ = SkipDatabaseCreation
             else:


### PR DESCRIPTION
We don't need them in zamboni and this saves us about 150 sql queries.
