### PR TITLE
Create client in FastFixtureTestCase._pre_setup.

### DIFF
--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -226,6 +226,7 @@ class FastFixtureTestCase(test.TransactionTestCase):
         test.testcases.disable_transaction_methods()
 
         #self._fixture_setup()
+        self.client = self.client_class()
         self._urlconf_setup()
         mail.outbox = []
 


### PR DESCRIPTION
Django's TestCase creates test client in `_pre_setup`. Since
FastFixtureTestCase overloads that method, to avoid fixture reloading,
we need to create the test client in the new _pre_setup method.
